### PR TITLE
Add funding link for when customers run `npm fund`

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,6 +2,7 @@
   "name": "@maplibre/maplibre-gl-compare",
   "version": "0.6.0-dev",
   "description": "Swipe and sync between two MapLibre maps",
+  "funding": "https://github.com/maplibre/maplibre-gl-js?sponsor=1",
   "main": "index.js",
   "directories": {
     "example": "example"


### PR DESCRIPTION
Add funding link

```bash
# npm fund
https://github.com/maplibre/maplibre-gl-js?sponsor=1
│ └── @maplibre/maplibre-gl-compare@0.6.0-dev
├─┬ https://opencollective.com/eslint
│ │ └── eslint@8.9.0
...
...
```