### PR TITLE
Add funding link for MapLibre GL JS when customers run `npm fund`

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -23,6 +23,9 @@
         "tape": "^5.5.2",
         "uglify-js": "^3.15.1"
       },
+      "funding": {
+        "url": "https://github.com/maplibre/maplibre-gl-js?sponsor=1"
+      },
       "peerDependencies": {
         "maplibre-gl": ">=2.1.6"
       }

--- a/package.json
+++ b/package.json
@@ -2,6 +2,7 @@
   "name": "@maplibre/maplibre-gl-compare",
   "version": "0.6.0-dev",
   "description": "Swipe and sync between two MapLibre maps",
+  "funding": "https://github.com/maplibre/maplibre-gl-js?sponsor=1",
   "main": "index.js",
   "directories": {
     "example": "example"


### PR DESCRIPTION
@HarelM  — thanks for the feedback on the lock file.  This change for funding in `package.json` indeed has a lock file. 