### PR TITLE
Update the compare 'Before' style 

### DIFF
--- a/example/index.js
+++ b/example/index.js
@@ -2,14 +2,18 @@
 
 require("../");
 
+// 'Before' style from https://github.com/lukasmartinelli/naturalearthtiles
 var before = new maplibregl.Map({
   container: "before",
-  style: "https://demotiles.maplibre.org/style.json",
+  style: "https://raw.githubusercontent.com/lukasmartinelli/naturalearthtiles/gh-pages/maps/natural_earth.vector.json",
+  zoom: 2
 });
 
+// 'After' style from https://github.com/maplibre/demotiles
 var after = new maplibregl.Map({
   container: "after",
   style: "https://demotiles.maplibre.org/style.json",
+  zoom: 2
 });
 
 // Use either of these patterns to select a container for the compare widget


### PR DESCRIPTION
Update the compare 'Before' style from https://github.com/lukasmartinelli/naturalearthtiles

Previously the _Compare demo_ was comparing identical styles.

_Example from the Safari mobile browser. Tested with `npm start`._
![MapLibre-Compare](https://user-images.githubusercontent.com/118112/192385061-df741864-8324-4da6-8209-39c2aa7dafce.gif)
