### PR TITLE
Update GitHub funding to match maplibre/maplibre-gl-js

### DIFF
--- a/.github/FUNDING.yml
+++ b/.github/FUNDING.yml
@@ -1,0 +1,2 @@
+github: [maplibre]
+open_collective: maplibre


### PR DESCRIPTION
Update "_Sponsor this project_" to point to MapLibre & Open Collective.

---

<img src="https://user-images.githubusercontent.com/118112/192853900-84bcec9a-b881-4673-bb4d-8936074d7a28.jpeg" width=50%>

